### PR TITLE
Use new validator factory to create instance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-commonware-avs-router = { git = "https://github.com/BreadchainCoop/commonware-avs-router", branch = "22-update-commonware-to-0055-and-refactor-lookup-repository-for-authenticated-p2p" }
+commonware-avs-router = { git = "https://github.com/BreadchainCoop/commonware-avs-router", branch = "dev" }
 
 alloy = { version = "0.12.6" }
 alloy-network = "0.5.4"

--- a/src/handlers/contributor.rs
+++ b/src/handlers/contributor.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use bn254::{self, Bn254, PublicKey, Signature as Bn254Signature};
 use bytes::Bytes;
-use commonware_avs_router::validator::Validator;
+use commonware_avs_router::validator::factory;
 use commonware_codec::{EncodeSize, ReadExt, Write};
 use commonware_cryptography::Signer;
 use commonware_p2p::{Receiver, Sender};
@@ -41,7 +41,7 @@ impl Contributor {
     ) -> Result<()> {
         let mut signed = HashSet::new();
         let mut signatures: HashMap<u64, HashMap<usize, Bn254Signature>> = HashMap::new();
-        let validator = Validator::new().await?;
+        let validator = factory::create_blockchain_validator().await?;
 
         while let Ok((s, message)) = receiver.recv().await {
             // Parse message


### PR DESCRIPTION
Use new factory function for creating a validator. Also update the `commonware-avs-router` dependency branch to `dev` which makes more sense to me as a default than the random branch it was set to.