### PR TITLE
Feat/add contributor unit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3093,6 +3093,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "tokio",
  "tracing",
  "tracing-subscriber 0.3.19",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ governor = "0.6.3"
 prometheus-client = "0.23.1"
 prost = "0.13.5"
 rand = "0.9.1"
-commonware-eigenlayer = {git = "https://github.com/BreadchainCoop/commonware-avs-network-lookup"}
+commonware-eigenlayer = { git = "https://github.com/BreadchainCoop/commonware-avs-network-lookup" }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_yaml = "0.9.34"
 tracing = "0.1.41"
@@ -48,6 +48,9 @@ serde_json = "1.0.140"
 
 [build-dependencies]
 prost-build = "0.13.5"
+
+[dev-dependencies]
+tokio = { version = "1.0", features = ["full", "test-util"] }
 
 [patch.crates-io]
 deranged = { git = "https://github.com/jhpratt/deranged", rev = "3c95431a375bca409a4731ae8749acc84e076267" }

--- a/src/contributor/mod.rs
+++ b/src/contributor/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+pub mod tests;
 pub mod traits;
 pub mod types;
 

--- a/src/contributor/tests/mock.rs
+++ b/src/contributor/tests/mock.rs
@@ -1,0 +1,183 @@
+use crate::contributor::{AggregationInput, Contribute, ContributorBase};
+use anyhow::Result;
+use ark_bn254::Fr;
+use bn254::{Bn254, PrivateKey, PublicKey, Signature as Bn254Signature};
+use commonware_cryptography::Signer;
+use commonware_p2p::{Receiver, Sender};
+use std::collections::HashMap;
+use std::error::Error as StdError;
+use std::fmt;
+
+/// Mock contributor for testing the trait implementations
+pub struct MockContributor {
+    pub orchestrator: PublicKey,
+    pub signer: Bn254,
+    pub me: usize,
+    pub contributors: Vec<PublicKey>,
+    pub ordered_contributors: HashMap<PublicKey, usize>,
+    pub aggregation_data: Option<AggregationInput>,
+}
+
+impl ContributorBase for MockContributor {
+    type PublicKey = PublicKey;
+    type Signer = Bn254;
+    type Signature = Bn254Signature;
+
+    fn is_orchestrator(&self, sender: &Self::PublicKey) -> bool {
+        &self.orchestrator == sender
+    }
+
+    fn get_contributor_index(&self, public_key: &Self::PublicKey) -> Option<&usize> {
+        self.ordered_contributors.get(public_key)
+    }
+}
+
+impl Contribute for MockContributor {
+    type AggregationInput = AggregationInput;
+
+    fn new(
+        orchestrator: PublicKey,
+        signer: Bn254,
+        mut contributors: Vec<PublicKey>,
+        aggregation_data: Option<AggregationInput>,
+    ) -> Self {
+        contributors.sort();
+        let mut ordered_contributors = HashMap::new();
+        for (idx, contributor) in contributors.iter().enumerate() {
+            ordered_contributors.insert(contributor.clone(), idx);
+        }
+        let me = *ordered_contributors.get(&signer.public_key()).unwrap();
+
+        Self {
+            orchestrator,
+            signer,
+            me,
+            contributors,
+            ordered_contributors,
+            aggregation_data,
+        }
+    }
+
+    async fn run<S, R>(self, _sender: S, _receiver: R) -> Result<()>
+    where
+        S: Sender,
+        R: Receiver<PublicKey = PublicKey>,
+    {
+        // Mock implementation - just return success
+        Ok(())
+    }
+}
+
+impl MockContributor {
+    /// Helper function to create Bn254 instances for testing using fixed values
+    pub fn create_test_bn254(seed: u64) -> Bn254 {
+        let fr = Fr::from(seed);
+        let private_key = PrivateKey::from(fr);
+        Bn254::new(private_key).expect("Failed to create Bn254 from private key")
+    }
+
+    /// Create a mock contributor with test data
+    pub fn new_test_contributor() -> Self {
+        let signer = Self::create_test_bn254(1);
+        let orchestrator = Self::create_test_bn254(2);
+        let contributor1 = Self::create_test_bn254(3);
+        let contributor2 = Self::create_test_bn254(4);
+
+        let contributors = vec![
+            signer.public_key(),
+            orchestrator.public_key(),
+            contributor1.public_key(),
+            contributor2.public_key(),
+        ];
+
+        let aggregation_input = AggregationInput::new(3, HashMap::new());
+
+        Self::new(
+            orchestrator.public_key(),
+            signer,
+            contributors,
+            Some(aggregation_input),
+        )
+    }
+
+    /// Create a mock contributor without aggregation data
+    pub fn new_simple_contributor() -> Self {
+        let signer = Self::create_test_bn254(5);
+        let orchestrator = Self::create_test_bn254(6);
+        let contributors = vec![signer.public_key(), orchestrator.public_key()];
+
+        Self::new(orchestrator.public_key(), signer, contributors, None)
+    }
+}
+
+// Custom error type for testing
+#[derive(Debug)]
+pub struct MockError(String);
+
+impl fmt::Display for MockError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "MockError: {}", self.0)
+    }
+}
+
+impl StdError for MockError {}
+
+// Mock implementations for testing async functionality
+#[derive(Debug, Clone)]
+pub struct MockSender {
+    sent_messages: std::sync::Arc<tokio::sync::Mutex<Vec<(String, bytes::Bytes, bool)>>>,
+}
+
+#[derive(Debug)]
+pub struct MockReceiver {
+    messages: std::sync::Arc<tokio::sync::Mutex<Vec<(PublicKey, bytes::Bytes)>>>,
+}
+
+impl MockSender {
+    pub fn new() -> Self {
+        Self {
+            sent_messages: std::sync::Arc::new(tokio::sync::Mutex::new(Vec::new())),
+        }
+    }
+}
+
+impl MockReceiver {
+    pub fn new() -> Self {
+        Self {
+            messages: std::sync::Arc::new(tokio::sync::Mutex::new(Vec::new())),
+        }
+    }
+}
+
+impl commonware_p2p::Sender for MockSender {
+    type Error = MockError;
+    type PublicKey = PublicKey;
+
+    async fn send(
+        &mut self,
+        _recipients: commonware_p2p::Recipients<Self::PublicKey>,
+        message: bytes::Bytes,
+        reliable: bool,
+    ) -> Result<Vec<Self::PublicKey>, Self::Error> {
+        let mut messages = self.sent_messages.lock().await;
+        messages.push(("mock_recipients".to_string(), message, reliable));
+        Ok(vec![]) // Return empty vector as required by the trait
+    }
+}
+
+impl commonware_p2p::Receiver for MockReceiver {
+    type Error = MockError;
+    type PublicKey = PublicKey;
+
+    async fn recv(&mut self) -> Result<(Self::PublicKey, bytes::Bytes), Self::Error> {
+        let mut messages = self.messages.lock().await;
+        if messages.is_empty() {
+            // Return a mock message to keep the test running
+            let mock_signer = MockContributor::create_test_bn254(999);
+            let mock_message = bytes::Bytes::from("mock message");
+            Ok((mock_signer.public_key(), mock_message))
+        } else {
+            Ok(messages.remove(0))
+        }
+    }
+}

--- a/src/contributor/tests/mod.rs
+++ b/src/contributor/tests/mod.rs
@@ -1,0 +1,2 @@
+pub mod mock;
+pub mod test_suite;

--- a/src/contributor/tests/test_suite.rs
+++ b/src/contributor/tests/test_suite.rs
@@ -1,0 +1,196 @@
+use super::mock::{MockContributor, MockReceiver, MockSender};
+use crate::contributor::{AggregationInput, Contribute, ContributorBase};
+use ark_bn254::Fr;
+use bn254::{Bn254, PrivateKey};
+use commonware_cryptography::Signer;
+use std::collections::HashMap;
+
+// Helper function to create Bn254 instances for testing using fixed values
+fn create_test_bn254(seed: u64) -> Bn254 {
+    let fr = Fr::from(seed);
+    let private_key = PrivateKey::from(fr);
+    Bn254::new(private_key).expect("Failed to create Bn254 from private key")
+}
+
+#[cfg(test)]
+mod contributor_base_tests {
+    use super::*;
+
+    #[test]
+    fn test_is_orchestrator() {
+        let contributor = MockContributor::new_test_contributor();
+
+        // Test with orchestrator's public key
+        assert!(contributor.is_orchestrator(&contributor.orchestrator));
+
+        // Test with non-orchestrator's public key
+        assert!(!contributor.is_orchestrator(&contributor.signer.public_key()));
+    }
+
+    #[test]
+    fn test_get_contributor_index() {
+        let contributor = MockContributor::new_test_contributor();
+
+        // Test with existing contributor
+        let index = contributor.get_contributor_index(&contributor.signer.public_key());
+        assert!(index.is_some());
+        assert_eq!(*index.unwrap(), contributor.me);
+
+        // Test with non-existent contributor
+        let random_signer = create_test_bn254(999);
+        let index = contributor.get_contributor_index(&random_signer.public_key());
+        assert!(index.is_none());
+    }
+
+    #[test]
+    fn test_get_contributor_index_with_simple_contributor() {
+        let contributor = MockContributor::new_simple_contributor();
+
+        // Test with existing contributor
+        let index = contributor.get_contributor_index(&contributor.signer.public_key());
+        assert!(index.is_some());
+
+        // Test with orchestrator
+        let index = contributor.get_contributor_index(&contributor.orchestrator);
+        assert!(index.is_some());
+    }
+}
+
+#[cfg(test)]
+mod contribute_tests {
+    use super::*;
+
+    #[test]
+    fn test_new_with_aggregation_data() {
+        let signer = create_test_bn254(10);
+        let orchestrator = create_test_bn254(11);
+        let contributor1 = create_test_bn254(12);
+
+        let contributors = vec![
+            signer.public_key(),
+            orchestrator.public_key(),
+            contributor1.public_key(),
+        ];
+
+        let aggregation_input = AggregationInput::new(2, HashMap::new());
+
+        let contributor = MockContributor::new(
+            orchestrator.public_key(),
+            signer,
+            contributors,
+            Some(aggregation_input),
+        );
+
+        assert_eq!(contributor.orchestrator, orchestrator.public_key());
+        assert_eq!(contributor.contributors.len(), 3);
+        assert!(contributor.aggregation_data.is_some());
+    }
+
+    #[test]
+    fn test_new_without_aggregation_data() {
+        let signer = create_test_bn254(20);
+        let orchestrator = create_test_bn254(21);
+        let contributors = vec![signer.public_key(), orchestrator.public_key()];
+
+        let contributor =
+            MockContributor::new(orchestrator.public_key(), signer, contributors, None);
+
+        assert_eq!(contributor.orchestrator, orchestrator.public_key());
+        assert_eq!(contributor.contributors.len(), 2);
+        assert!(contributor.aggregation_data.is_none());
+    }
+
+    #[test]
+    fn test_contributors_are_sorted() {
+        let signer = create_test_bn254(30);
+        let orchestrator = create_test_bn254(31);
+        let contributor1 = create_test_bn254(32);
+        let contributor2 = create_test_bn254(33);
+
+        // Create contributors in unsorted order
+        let contributors = vec![
+            contributor2.public_key(),
+            signer.public_key(),
+            contributor1.public_key(),
+            orchestrator.public_key(),
+        ];
+
+        let contributor =
+            MockContributor::new(orchestrator.public_key(), signer, contributors, None);
+
+        // Verify contributors are sorted
+        let mut sorted_contributors = contributor.contributors.clone();
+        sorted_contributors.sort();
+        assert_eq!(contributor.contributors, sorted_contributors);
+    }
+
+    #[test]
+    fn test_me_index_calculation() {
+        let signer = create_test_bn254(40);
+        let orchestrator = create_test_bn254(41);
+        let contributor1 = create_test_bn254(42);
+
+        let signer_pubkey = signer.public_key();
+        let contributors = vec![
+            signer_pubkey.clone(),
+            orchestrator.public_key(),
+            contributor1.public_key(),
+        ];
+
+        let contributor =
+            MockContributor::new(orchestrator.public_key(), signer, contributors, None);
+
+        // Verify that me index corresponds to the signer's position in sorted contributors
+        let signer_index = contributor.get_contributor_index(&signer_pubkey).unwrap();
+        assert_eq!(contributor.me, *signer_index);
+    }
+
+    #[tokio::test]
+    async fn test_run_method() {
+        let contributor = MockContributor::new_test_contributor();
+
+        // Create mock sender and receiver
+        let sender = MockSender::new();
+        let receiver = MockReceiver::new();
+
+        // Test that the run method completes successfully
+        let result = contributor.run(sender, receiver).await;
+        assert!(result.is_ok());
+    }
+}
+
+#[cfg(test)]
+mod aggregation_input_tests {
+    use super::*;
+
+    #[test]
+    fn test_aggregation_input_creation() {
+        let threshold = 3;
+        let g1_map = HashMap::new();
+
+        let aggregation_input = AggregationInput::new(threshold, g1_map);
+
+        assert_eq!(aggregation_input.threshold(), threshold);
+        assert!(aggregation_input.g1_map().is_empty());
+    }
+
+    #[test]
+    fn test_aggregation_input_with_g1_map() {
+        let threshold = 2;
+        let mut g1_map = HashMap::new();
+        let signer = create_test_bn254(50);
+        // Create a simple G1 key for testing (using default coordinates)
+        let g1_key = bn254::G1PublicKey::create_from_g1_coordinates("0", "0").unwrap();
+        g1_map.insert(signer.public_key(), g1_key);
+
+        let aggregation_input = AggregationInput::new(threshold, g1_map);
+
+        assert_eq!(aggregation_input.threshold(), threshold);
+        assert_eq!(aggregation_input.g1_map().len(), 1);
+        assert!(
+            aggregation_input
+                .g1_map()
+                .contains_key(&signer.public_key())
+        );
+    }
+}


### PR DESCRIPTION
Add unit tests for contributor. Downstream from https://github.com/BreadchainCoop/commonware-avs-node/pull/43 so that would need to be merged in first.