### PR TITLE
feat: Add TLSN-Noir integration support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-commonware-avs-router = { git = "https://github.com/BreadchainCoop/commonware-avs-router", branch = "main" }
+commonware-avs-router = { git = "https://github.com/OpacityLabs/opacity-commonware-avs-router", branch = "tlsn-integration" }
 
 alloy = { version = "0.12.6" }
 alloy-network = "0.5.4"


### PR DESCRIPTION
This PR integrates TLSN-Noir support by pointing to the router's tlsn-integration branch.

## Changes
- Update Cargo.toml to depend on OpacityLabs/opacity-commonware-avs-router#tlsn-integration

## Related PRs
- Router PR: OpacityLabs/opacity-commonware-avs-router#39

## Testing
This PR will trigger CI to build a Docker image tagged as `pr-{number}` that can be used in docker-compose for testing the TLSN integration.

## Implementation Details
The router PR adds complete TLSN node integration in `validator.rs`:
- TlsnOpacityNode with MPC-TLS server
- Proof verification using bb-service
- BLS signature generation
- P2P aggregation integration

Once this PR is merged and the router PR is merged, the main branch will include full TLSN support.